### PR TITLE
chore: migrate references to Act Security

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Cloud Copilot
+Copyright (c) 2024 Act Security
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Data is scanned daily and a new version is published if there are changes. The v
 ## Usage
 
 ```bash
-npm install @cloud-copilot/iam-data
+npm install @actsecurity/iam-data
 ```
 
 ```typescript
-import { iamServiceKeys, iamActionDetails, iamActionsForService, iamServiceName } from '@cloud-copilot/iam-data';
+import { iamServiceKeys, iamActionDetails, iamActionsForService, iamServiceName } from '@actsecurity/iam-data';
 
 // Iterate through all actions in all services
 const serviceKeys = await iamServiceKeys()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,21 @@
       "version": "0.21.202609011",
       "license": "MIT",
       "devDependencies": {
-        "@cloud-copilot/prettier-config": "^0.1.1",
+        "@actsecurity/prettier-config": "^0.1.1",
         "@types/node": "^22.5.0",
         "@vitest/coverage-v8": "^4.0.18",
         "typescript": "^5.5.4",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@actsecurity/prettier-config": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@actsecurity/prettier-config/-/prettier-config-0.1.2.tgz",
+      "integrity": "sha512-dubgoNGichG1ZIyhWx1dF9AJwfkAlx9q1SJeas3ebk8UXv96BgDzYt4oc40GFvTh39enZrO7Dte5jBTh/ToxeQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": "^3.4.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -74,16 +84,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@cloud-copilot/prettier-config": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/prettier-config/-/prettier-config-0.1.2.tgz",
-      "integrity": "sha512-7vfEqnRwC07NrCCSU1XSSUaePbGYldv3TWB1W6WtE6JJblsqFDXBz6yZHzO7uJRMl7FbalpVkluTYykdFh1a/g==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "prettier": "^3.4.2"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   "author": "David Kerber <dave@cloudcopilot.io>",
   "license": "MIT",
   "devDependencies": {
-    "@cloud-copilot/prettier-config": "^0.1.1",
+    "@actsecurity/prettier-config": "^0.1.1",
     "@types/node": "^22.5.0",
     "@vitest/coverage-v8": "^4.0.18",
     "typescript": "^5.5.4",
     "vitest": "^4.0.18"
   },
-  "prettier": "@cloud-copilot/prettier-config"
+  "prettier": "@actsecurity/prettier-config"
 }


### PR DESCRIPTION
## Summary\n- update README package references to @actsecurity/iam-data\n- update package prettier config dependency scope to @actsecurity\n- update license copyright holder to Act Security\n- regenerate package-lock.json after package scope migration\n\n## Validation\n- npm install\n- npm run format\n- npm run build\n- npm test